### PR TITLE
restrict refresh ring to heartBeat

### DIFF
--- a/control.go
+++ b/control.go
@@ -381,7 +381,7 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 		return
 	}
 
-	c.reconnect(true)
+	c.reconnect(false)
 }
 
 func (c *controlConn) getConn() *connHost {


### PR DESCRIPTION
GetHosts uses queries on control connection. Any query error will
cause reconnection and refresh ring which calls GetHosts and thus
deadlocks.

Also it seems neater to have the ring refresh be done only by heartBeat.

Fixes #928

